### PR TITLE
Allow spaces on session name field and quoting of strings on command call ...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PREFIX = /usr/local
+
 all: saplisten
 
 saplisten: $(patsubst %.c,%.o,$(wildcard *.c))
@@ -5,3 +7,7 @@ saplisten: $(patsubst %.c,%.o,$(wildcard *.c))
 
 %.o: %.c
 	gcc -std=gnu99 -ggdb -c -o $@ $^
+
+install: saplisten
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	cp $< $(DESTDIR)$(PREFIX)/bin/saplisten

--- a/main.c
+++ b/main.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
         if (command) {
             char cmd[1024] = {};
             int ret = snprintf(
-                cmd, sizeof(cmd), "%s %s %s %s %s %d %d %d %s",
+                cmd, sizeof(cmd), "%s \"%s\" \"%s\" \"%s\" \"%s\" %d %d %d \"%s\"",
                 command,
                 sdp->origin,
                 sdp->session,

--- a/sdp.c
+++ b/sdp.c
@@ -128,7 +128,7 @@ sdp_info *sdp_parse(const char *t, int is_goodbye) {
             char a[64];
             strlcpy(a, t+2, l-1);
 
-            a[strcspn(a, " ")] = 0;
+            //a[strcspn(a, " ")] = 0;
             i->session = strdup(a);
         } else if (startswith(t, "c=IN IP4 ")) {
             char a[64];


### PR DESCRIPTION

    "Text fields such as the session name and information are octet
    strings that may contain any octet with the exceptions of 0x00 (Nul),
    0x0a (ASCII newline), and 0x0d (ASCII carriage return)."

    https://tools.ietf.org/html/rfc4566#section-5

Also add install target to Makefile.